### PR TITLE
Change GenomeCoverageBed to use the genome_id param.

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -807,14 +807,14 @@ process bedgraphs {
     genomeCoverageBed \
                      -bg \
                      -strand + \
-                     -g ${genome_id} \
+                     -g ${chrom_sizes} \
                      -ibam ${bam_file} \
                      > ${name}.pos.bedGraph
 
     genomeCoverageBed \
                      -bg \
                      -strand - \
-                     -g ${genome_id} \
+                     -g ${chrom_sizes} \
                      -ibam ${bam_file} \
                      > ${name}.tmp.neg.bedGraph
 

--- a/main.nf
+++ b/main.nf
@@ -807,14 +807,14 @@ process bedgraphs {
     genomeCoverageBed \
                      -bg \
                      -strand + \
-                     -g hg38 \
+                     -g ${genome_id} \
                      -ibam ${bam_file} \
                      > ${name}.pos.bedGraph
 
     genomeCoverageBed \
                      -bg \
                      -strand - \
-                     -g hg38 \
+                     -g ${genome_id} \
                      -ibam ${bam_file} \
                      > ${name}.tmp.neg.bedGraph
 


### PR DESCRIPTION
Previously this code had the genome hard-coded as hg38 in the
genomeCoverageBed step of the pipeline. This commit changes this to
instead use the required parameter genome_id.

I'm currently testing this change.

Fixes #2 